### PR TITLE
Fix code review findings

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -6,6 +6,9 @@ on:
     tags: [v*]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-release:
     runs-on: windows-latest
@@ -30,4 +33,6 @@ jobs:
         run: npm run package
       - name: Publish to Visual Studio Marketplace
         if: startsWith(github.ref, 'refs/tags/')
-        run: npx vsce publish -p ${{ secrets.VSCE_TOKEN }}
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+        run: npx vsce publish -p "$env:VSCE_TOKEN"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  integration-test:
+  check-formatting:
     runs-on: windows-latest
     steps:
       - name: Checkout repository with submodules

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   get-jbeam-edit-versions:
     name: Get jbeam-edit versions

--- a/scripts/Get-Releases.ps1
+++ b/scripts/Get-Releases.ps1
@@ -20,10 +20,10 @@ if ($selectedRelease) {
 
 $vscodeVersions = @($minVscodeVersion, "stable")
 
-$matrix = @()
+$matrix = [System.Collections.Generic.List[object]]::new()
 foreach ($jbeam in $jbeamVersions) {
     foreach ($vscode in $vscodeVersions) {
-        $matrix += @{ jbeam_lsp_server = $jbeam; vscode_version = $vscode }
+        $matrix.Add(@{ jbeam_lsp_server = $jbeam; vscode_version = $vscode })
     }
 }
 

--- a/scripts/setup_jbeam_server.ps1
+++ b/scripts/setup_jbeam_server.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = "Stop"
 
-Write-Host "Creating directory $zipDir..."
 $zipDir = "C:\jbeam-lsp-server"
+Write-Host "Creating directory $zipDir..."
 New-Item -ItemType Directory -Force -Path $zipDir | Out-Null
 Write-Host "Directory created."
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import {
   ServerOptions,
 } from 'vscode-languageclient/node';
 
-let client: LanguageClient;
+let client: LanguageClient | undefined;
 
 interface LSPPosition {
   line: number;
@@ -114,8 +114,9 @@ export async function activate(context: vscode.ExtensionContext) {
         console.log('[jbeam] no edits returned from server');
       }
     } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       console.error('[jbeam] JBeam format failed:', err);
-      vscode.window.showErrorMessage('JBeam format failed: ' + err);
+      vscode.window.showErrorMessage('JBeam format failed: ' + msg);
     }
   });
 
@@ -127,7 +128,9 @@ export async function activate(context: vscode.ExtensionContext) {
     await client.start();
     console.log('[jbeam] client started');
   } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
     console.error('[jbeam] client.start() failed:', err);
+    vscode.window.showErrorMessage('JBeam LSP server failed to start: ' + msg);
   }
 }
 


### PR DESCRIPTION
## Summary

- **`setup_jbeam_server.ps1`**: Move `$zipDir` assignment before the `Write-Host` that uses it (was printing an empty path in CI logs)
- **`extension.ts`**: Type `client` as `LanguageClient | undefined` to accurately reflect that it may be unset before activation
- **`extension.ts`**: Show an error message to the user when `client.start()` fails, instead of only logging to console
- **`extension.ts`**: Use `err instanceof Error ? err.message : String(err)` instead of `+ err` to avoid `[object Object]` in error messages
- **`Get-Releases.ps1`**: Replace `+=` array building in loop with `List[object]` to avoid O(n²) copies
- **`build-and-release.yaml`**: Pass `VSCE_TOKEN` via `env` instead of interpolating the secret directly in the `run` string
- All three workflows: Add `permissions: contents: read` block
- `format.yml`: Rename job from `integration-test` to `check-formatting`

## Test plan

- [x] Run `npm run lint` locally to verify TypeScript changes
- [x] Trigger the format workflow and confirm it still passes
- [x] Confirm the release workflow no longer interpolates the secret directly